### PR TITLE
/=/ Syntax bug

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -553,7 +553,7 @@
 			<key>comment</key>
 			<string>Needs higher precidence than regular expressions.</string>
 			<key>match</key>
-			<string>/=</string>
+			<string>^\(/=</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.augmented.ruby</string>
 		</dict>


### PR DESCRIPTION
Fix a little bug, where expression like "a=b=c".split(/=/) breaks the text parser, because the /= is interpreted  as operator assignment and the rest as regular expression.
