### PR TITLE
Completion command fixed.

### DIFF
--- a/Commands/Completion: Ruby (rcodetools).tmCommand
+++ b/Commands/Completion: Ruby (rcodetools).tmCommand
@@ -42,7 +42,7 @@ command     = &lt;&lt;END_COMMAND.tr("\n", " ").strip
 --column=#{ENV['TM_LINE_INDEX']}
 2&gt; /dev/null
 END_COMMAND
-completions = `#{command}`.to_a.map { |l| l.strip }.select { |l| l =~ /\S/ }
+completions = `#{command}`.split("\n").map { |l| l.strip }.select { |l| l =~ /\S/ }
 
 if not $?.success?
   TextMate.exit_show_tool_tip "Parse error."


### PR DESCRIPTION
Replaced the call to `to_a` on the results so that an array is returned by splitting on newlines instead.

``` ruby
completions = `#{command}`.split("\n").map { |l| l.strip }.select { |l| l =~ /\S/ }
```
