### PR TITLE
Fix interpolation within syntax-highlighted heredocs

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -1707,11 +1707,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>text.html.basic</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>text.html.basic</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1754,11 +1754,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.sql</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.sql</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1801,11 +1801,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.css</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.css</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1848,11 +1848,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.c++</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.c++</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1895,11 +1895,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.c</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.c</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1942,11 +1942,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.js</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.js</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -1989,11 +1989,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.js.jquery</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.js.jquery</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -2036,11 +2036,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.shell</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.shell</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -2083,11 +2083,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.ruby</string>
+					<string>#interpolated_ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#interpolated_ruby</string>
+					<string>source.ruby</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
Prioritising interpolated_ruby above the language highlighting allows interpolations in <<-LANG-style heredocs.

Before: http://d.pr/qwGh

After: http://d.pr/zh9C
