### PR TITLE
Added <string>prawn</string> to Syntaxes/Ruby.plist

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -56,6 +56,7 @@
 		<string>gemspec</string>
 		<string>irbrc</string>
 		<string>capfile</string>
+		<string>prawn</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>^#!/.*\bruby</string>


### PR DESCRIPTION
The pdf templating gem Prawn uses .prawn files for the views. These .prawn files are just plain ruby files so they should be in the ruby file list.
