### PR TITLE
Indent should still decrease when chaining methods on the end of curly braced block

### DIFF
--- a/Preferences/Miscellaneous.plist
+++ b/Preferences/Miscellaneous.plist
@@ -9,7 +9,7 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^\s*([}\]],?\s*(#|$)|(end|rescue|ensure|else|elsif|when)\b)</string>
+		<string>^\s*([}\]](,?|\.[a-z]*)(\s|.)*(#|$)|(end|rescue|ensure|else|elsif|when)\b)</string>
 		<key>increaseIndentPattern</key>
 		<string>(?x)^
     (\s*


### PR DESCRIPTION
As a disclaimer I feel I must note that this is my first ever attempt at contributing to open source software, so if I went about something incorrectly please let me know so I don't repeat it in the future.

I write a lot of RSpec tests, and the following shows up in my code quite a bit.

``` ruby
expect {
   some_action
}.to change { some_attribute_of_something }.from( nil ).to "Super Awesome"
```

The issue that I've addressed here is that the above code always comes out as the following:

``` ruby
expect {
   some_action
   }.to change { some_attribute_of_something }.from( nil ).to "Super Awesome"
```

The indenting scheme makes it look at first glance like the stuff thats chained onto the block is in it. I used to use TM1 and never had this issue, it only showed up once I started using TM2. I'm not entirely sure what changed, but I've been using this fix for about a week now without any adverse side effects I could notice.

Thanks for taking the time to look at this pull request.
