### PR TITLE
Rename variable name to get clean output for CMD-R when using Ruby 1.9+

### DIFF
--- a/Support/RubyMate/catch_exception.rb
+++ b/Support/RubyMate/catch_exception.rb
@@ -22,7 +22,7 @@ at_exit do
         file, line, method = $1, $2, $3
         url, display_name = '', file
 
-        path = dirs.map{ |dir| File.expand_path(file, dir) }.find{ |path| File.file? path }
+        path = dirs.map{ |dir| File.expand_path(file, dir) }.find{ |filename| File.file? filename }
         unless path.nil?
           url, display_name = '&amp;url=file://' + e_url(path), File.basename(path)
         end


### PR DESCRIPTION
![Screen Shot 2013-04-09 at 14 39 49](https://f.cloud.github.com/assets/7542/356856/403768f6-a117-11e2-9533-2b81c090ef59.png)

When using Ruby versions >= 1.9 to run scripts via CMD-R, the warning
"shadowing outer local variable" is generated (assuming the -w switch
is set) and copied to the output window.

Renames the inner variable to avoid the message and get a clean output.
