### PR TITLE
Syntax highlighting for Ruby 2.0 symbol arrays

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -1160,7 +1160,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\(</string>
+			<string>%[QWSRI]?\(</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1201,7 +1201,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\[</string>
+			<string>%[QWSRI]?\[</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1242,7 +1242,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\&lt;</string>
+			<string>%[QWSRI]?\&lt;</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1283,7 +1283,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\{</string>
+			<string>%[QWSRI]?\{</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1324,7 +1324,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]([^\w])</string>
+			<string>%[QWSRI]([^\w])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
This commit adds syntax highlighting for Ruby 2.0 symbol arrays. For example:

```
%i{ one two three }
```