### PR TITLE
make rakemate compatible with ruby 1.9

### DIFF
--- a/Support/RakeMate/rake_mate.rb
+++ b/Support/RakeMate/rake_mate.rb
@@ -46,7 +46,7 @@ if tasks.include? "No Rakefile found"
   html_error("Could not locate a Rakefile in #{RAKEFILE_DIR}.")
 end
 
-tasks = [DEFAULT_TASK] + tasks.grep(/^rake\s+(\S+)/) { |t| t.split[1] }
+tasks = [DEFAULT_TASK] + tasks.lines.grep(/^rake\s+(\S+)/) { |t| t.split[1] }
 if last_task = tasks.index(prefs.transaction(true) { prefs[RAKEFILE_DIR] })
   tasks.unshift(tasks.slice!(last_task))
 end


### PR DESCRIPTION
make rakemate compatible with ruby 1.9,  by using .line tasks.
