### PR TITLE
Add contentName to quoted string grammar

### DIFF
--- a/Commands/Check ERB Syntax.plist
+++ b/Commands/Check ERB Syntax.plist
@@ -6,11 +6,26 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/usr/bin/env ruby18
+require "shellwords"
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
+
 puts "Using " + `"${TM_RUBY:=ruby}" -e'puts "ruby-" + RUBY_VERSION.to_s'`.chomp + " / " + `"${TM_ERB:=erb}" --version 2&gt;&amp;1`.chomp
 result = `"${TM_ERB:=erb}" -T - -x | "${TM_RUBY:=ruby}" -c 2&gt;&amp;1`
-puts result
-TextMate.go_to :line =&gt; $1 if result =~ /-:(\d+):/</string>
+
+if result =~ /-:(\d+):(.*)/
+  TextMate.go_to :line =&gt; $1
+  puts $2
+  `#{ENV["TM_MATE"]} -c warning`
+  result.each_line do |line|
+    if line =~ /-:(\d+):(.*)/
+      `#{ENV["TM_MATE"]} --set-mark warning:#{Shellwords.escape($2)} --line #{$1}`
+    end
+  end
+else
+  puts result
+  `#{ENV["TM_MATE"]} -c warning`
+end
+    </string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>

--- a/Commands/Check Ruby Syntax.plist
+++ b/Commands/Check Ruby Syntax.plist
@@ -6,11 +6,25 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/usr/bin/env ruby18
+require "shellwords"
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
+
 puts `"${TM_RUBY:=ruby}" -e'puts "Using ruby-" + RUBY_VERSION.to_s'`
 result = `"${TM_RUBY:=ruby}" -wc 2&gt;&amp;1`
-puts result
-TextMate.go_to :line =&gt; $1 if result =~ /-:(\d+):/
+
+if result =~ /-:(\d+):(.*)/
+  TextMate.go_to :line =&gt; $1
+  puts $2
+  `#{ENV["TM_MATE"]} -c warning`
+  result.each_line do |line|
+    if line =~ /-:(\d+):(.*)/
+      `#{ENV["TM_MATE"]} --set-mark warning:#{Shellwords.escape($2)} --line #{$1}`
+    end
+  end
+else
+  puts result
+  `#{ENV["TM_MATE"]} -c warning`
+end
 </string>
 	<key>input</key>
 	<string>document</string>

--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -638,6 +638,8 @@
 			</dict>
 			<key>comment</key>
 			<string>single quoted string (does not allow interpolation)</string>
+			<key>contentName</key>
+			<string>string.content.quoted.single.ruby</string>
 			<key>end</key>
 			<string>'</string>
 			<key>endCaptures</key>
@@ -673,6 +675,8 @@
 			</dict>
 			<key>comment</key>
 			<string>double quoted string (allows for interpolation)</string>
+			<key>contentName</key>
+			<string>string.content.quoted.double.ruby</string>
 			<key>end</key>
 			<string>"</string>
 			<key>endCaptures</key>


### PR DESCRIPTION
Allows selecting string contents via "Select -> Current Scope"
without the quotes on the first press, with quotes on the second
press.