### PR TITLE
Megapack

### DIFF
--- a/Commands/@variable ||= memoized.tmCommand
+++ b/Commands/@variable ||= memoized.tmCommand
@@ -8,19 +8,26 @@
 	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
 
 line_number = ENV['TM_LINE_NUMBER'].to_i - 1
-line = STDIN.lines.to_a[line_number-1]
+# line = STDIN.lines.to_a[line_number-1]
+# method_name = $1 if line =~ /def (?:self\.)?([a-z\d_]+)/i
 
-ivar_name = 'instance_variable'
-ivar_name = $1 if line =~ /def (?:self\.)?([a-z\d_]+)/i
+method_name = nil
+lines = STDIN.lines.to_a[0..line_number-1].reverse
+line = lines.find {|l| l =~ /\bdef (?:self\.)?([a-zA-Z\d_]+)/}
+method_name = $1 if line
 
-print "@${1:#{ivar_name}} ||= $0"
+ivar_name = (method_name != 'initialize' &amp;&amp; method_name) || 'instance_variable'
+assignment = method_name == 'initialize' ? '=' : '${2:||}='
+
+print "@${1:#{ivar_name}} #{assignment} "
+print '${3:$1}' unless ENV['TM_CURRENT_WORD']
 </string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>name</key>
-	<string>@variable ||= memoized</string>
+	<string>@variable</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>

--- a/Commands/@variable ||= memoized.tmCommand
+++ b/Commands/@variable ||= memoized.tmCommand
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+
+line_number = ENV['TM_LINE_NUMBER'].to_i - 1
+line = STDIN.lines.to_a[line_number-1]
+
+ivar_name = 'instance_variable'
+ivar_name = $1 if line =~ /def (?:self\.)?([a-z\d_]+)/i
+
+print "@${1:#{ivar_name}} ||= $0"
+</string>
+	<key>input</key>
+	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>name</key>
+	<string>@variable ||= memoized</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>snippet</string>
+	<key>outputLocation</key>
+	<string>atCaret</string>
+	<key>scope</key>
+	<string>source.ruby</string>
+	<key>tabTrigger</key>
+	<string>@</string>
+	<key>uuid</key>
+	<string>20ACDEEE-1F1D-4CFB-8B66-940E902693EF</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Commands/@variable ||= memoized.tmCommand
+++ b/Commands/@variable ||= memoized.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
+	<string>#!/usr/bin/env ruby18
 
 line_number = ENV['TM_LINE_NUMBER'].to_i - 1
 # line = STDIN.lines.to_a[line_number-1]

--- a/Snippets/#inspect.tmSnippet
+++ b/Snippets/#inspect.tmSnippet
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string>inspect</string>
+	<key>name</key>
+	<string>#inspect</string>
+	<key>scope</key>
+	<string>source.ruby</string>
+	<key>tabTrigger</key>
+	<string>i</string>
+	<key>uuid</key>
+	<string>2BB6D28F-914E-4132-BC53-E43CF5060BFA</string>
+</dict>
+</plist>

--- a/Snippets/class .. end  (cla).plist
+++ b/Snippets/class .. end  (cla).plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.rb)?/(?2::\u$1)/g}}
+	<string>class ${1:${TM_FILENAME/(?:\A|_)([A-Za-z0-9]+)(?:\.[a-z]+)*/(?2::\u$1)/g}}
 	$0
 end</string>
 	<key>name</key>

--- a/Snippets/require '..'  (req).plist
+++ b/Snippets/require '..'  (req).plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>require "$0"</string>
+	<string>require '$0'</string>
 	<key>name</key>
-	<string>require ".."</string>
+	<string>require '..'</string>
 	<key>scope</key>
 	<string>source.ruby</string>
 	<key>tabTrigger</key>

--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -1189,7 +1189,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\(</string>
+			<string>%[QWSRI]?\(</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1230,7 +1230,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\[</string>
+			<string>%[QWSRI]?\[</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1271,7 +1271,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\&lt;</string>
+			<string>%[QWSRI]?\&lt;</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1312,7 +1312,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]?\{</string>
+			<string>%[QWSRI]?\{</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1353,7 +1353,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[QWSR]([^\w])</string>
+			<string>%[QWSRI]([^\w])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1427,7 +1427,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[qws]\(</string>
+			<string>%[qwsi]\(</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1466,7 +1466,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[qws]\&lt;</string>
+			<string>%[qwsi]\&lt;</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1505,7 +1505,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[qws]\[</string>
+			<string>%[qwsi]\[</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1544,7 +1544,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[qws]\{</string>
+			<string>%[qwsi]\{</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -1583,7 +1583,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>%[qws]([^\w])</string>
+			<string>%[qwsi]([^\w])</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
I'll propose all this stuff at once, **but I'm ready to split into different PRs** if you want just a subset.

- Add support for Rational/Complex Literal (Ruby 2.1), e.g. `23i` and `23r`
- Add Symbols (Intern) percent string support, e.g. `%i[some symbols]` and  `%I[some #{:symbols}]`
- Add <kbd>i⇥</kbd> to insert `inspect`
- Add @ expantion to memoized ivar (see below)
- Skip multiple extensions in the class name, e.g. the class name generated from a file named `my_class.js.rb` will be `MyClass` instead of `MyClass.js`


---

### Add @ expansion to memoized ivar

Will expand `@` to a memoized assignment of a variable with the same name as the including method.

#### General case

```ruby
def some_method
  @⇥
end
```
is expanded to:
```ruby
def some_method
  @some_method ||= some_method
end
```

#### With previous content

```ruby
def some_method
  @⇥previous_content
end
```
is expanded to:

```ruby
def some_method
  @some_method ||= previous_content
end
```

#### Inside `initialize`

```ruby
def initialize
  @⇥
end
```
is expanded to:

```ruby
def initialize
  @instance_variable = instance_variable
end
```



