### PR TITLE
ruby: The `/=` operator doesn't need augmented priority

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -625,14 +625,6 @@
 			</array>
 		</dict>
 		<dict>
-			<key>comment</key>
-			<string>Needs higher precidence than regular expressions.</string>
-			<key>match</key>
-			<string>(?&lt;!\()/=</string>
-			<key>name</key>
-			<string>keyword.operator.assignment.augmented.ruby</string>
-		</dict>
-		<dict>
 			<key>begin</key>
 			<string>'</string>
 			<key>beginCaptures</key>
@@ -2447,7 +2439,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>&lt;&lt;=|%=|&amp;=|\*=|\*\*=|\+=|\-=|\^=|\|{1,2}=|&lt;&lt;</string>
+			<string>&lt;&lt;=|%=|&amp;=|\*=|\*\*=|/=|\+=|\-=|\^=|\|{1,2}=|&lt;&lt;</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.augmented.ruby</string>
 		</dict>


### PR DESCRIPTION
Unless I am mistaken, this was only relevant before the regexp matches had heuristics tor precedence. Now it causes weird behavior.

Removing this augmented priority fixes many issues with regexes that begin with `/=`.

For instance, the following expression in a switch statement would fail to be highlighted before this patch: `case /=/\n`, and instead be interpreted as a `/=` and the start of a multi-line regexp.