### PR TITLE
Recognize heredocs in argument lists

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -2332,7 +2332,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?&gt;\=\s*&lt;&lt;(\w+))</string>
+			<string>(?&gt;[=,]\s*&lt;&lt;(\w+))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
We now allow heredocs to be preceded by commas, as they are in code such as the following:

``` ruby
    send :method, <<EOF
      hello
    EOF
```
