### PR TITLE
Add Cheffile and Hobofile to Syntaxes/Ruby.plist

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -58,8 +58,10 @@
 		<string>capfile</string>
 		<string>ru</string>
 		<string>prawn</string>
+		<string>Cheffile</string>
 		<string>Gemfile</string>
 		<string>Guardfile</string>
+		<string>Hobofile</string>
 		<string>Vagrantfile</string>
 		<string>Appraisals</string>
 		<string>Rantfile</string>


### PR DESCRIPTION
As usually the `Cheffile` and `Hobofile` contain Ruby syntax whenever the relative tools using them are being used. This should allow them to be coloured accordingly when used inside an IDE.