### PR TITLE
Syntax checker now populates the gutter

### DIFF
--- a/Commands/Check ERB Syntax.plist
+++ b/Commands/Check ERB Syntax.plist
@@ -6,11 +6,24 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/usr/bin/env ruby18
+require "shellwords"
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
+
 puts "Using " + `"${TM_RUBY:=ruby}" -e'puts "ruby-" + RUBY_VERSION.to_s'`.chomp + " / " + `"${TM_ERB:=erb}" --version 2&gt;&amp;1`.chomp
-result = `"${TM_ERB:=erb}" -T - -x | "${TM_RUBY:=ruby}" -c 2&gt;&amp;1`
-puts result
-TextMate.go_to :line =&gt; $1 if result =~ /-:(\d+):/</string>
+puts result = `"${TM_ERB:=erb}" -T - -x | "${TM_RUBY:=ruby}" -c 2&gt;&amp;1`
+
+if result =~ /-:(\d+):(.*)/
+  TextMate.go_to :line =&gt; $1
+  `"$TM_MATE" -c warning`
+  result.each_line do |line|
+    if line =~ /-:(\d+):(.*)/
+      `"$TM_MATE" --set-mark warning:#{Shellwords.escape($2)} --line #{$1}`
+    end
+  end
+else
+  `"$TM_MATE" -c warning`
+end
+    </string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>

--- a/Commands/Check Ruby Syntax.plist
+++ b/Commands/Check Ruby Syntax.plist
@@ -6,11 +6,23 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/usr/bin/env ruby18
+require "shellwords"
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
+
 puts `"${TM_RUBY:=ruby}" -e'puts "Using ruby-" + RUBY_VERSION.to_s'`
-result = `"${TM_RUBY:=ruby}" -wc 2&gt;&amp;1`
-puts result
-TextMate.go_to :line =&gt; $1 if result =~ /-:(\d+):/
+puts result = `"${TM_RUBY:=ruby}" -wc 2&gt;&amp;1`
+
+if result =~ /-:(\d+):(.*)/
+  TextMate.go_to :line =&gt; $1
+  `"$TM_MATE" -c warning`
+  result.each_line do |line|
+    if line =~ /-:(\d+):(.*)/
+      `"$TM_MATE" --set-mark warning:#{Shellwords.escape($2)} --line #{$1}`
+    end
+  end
+else
+  `"$TM_MATE" -c warning`
+end
 </string>
 	<key>input</key>
 	<string>document</string>


### PR DESCRIPTION
Currently, the output of the syntax check is shown in a simple balloon popover. With this patch, the new gutter is populated line by line with a warning sign containing the error message.