### PR TITLE
Fixed capturing groups in meta.class.ruby

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -84,12 +84,12 @@
 				<key>4</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.inherited-class.ruby</string>
+					<string>punctuation.separator.inheritance.ruby</string>
 				</dict>
 				<key>5</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.separator.inheritance.ruby</string>
+					<string>entity.other.inherited-class.ruby</string>
 				</dict>
 				<key>6</key>
 				<dict>
@@ -103,7 +103,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(class)\s+(([.a-zA-Z0-9_:]+(\s*(&lt;)\s*[.a-zA-Z0-9_:]+)?)|((&lt;&lt;)\s*[.a-zA-Z0-9_:]+))</string>
+			<string>^\s*(class)\s+(([.a-zA-Z0-9_:]+\s*(&lt;)\s*([.a-zA-Z0-9_:]+)?)|((&lt;&lt;)\s*[.a-zA-Z0-9_:]+))</string>
 			<key>name</key>
 			<string>meta.class.ruby</string>
 		</dict>


### PR DESCRIPTION
Moved the inheritance operator out of the inherited class's group.
This will solve a little issue with syntax coloring (see below).
**Before**
![screen shot 2015-09-08 at 20 22 12](https://cloud.githubusercontent.com/assets/9920504/9743584/769cef76-5667-11e5-9953-0088c4e9c5c1.png)
**After**
![screen shot 2015-09-08 at 20 20 52](https://cloud.githubusercontent.com/assets/9920504/9743604/8e716d84-5667-11e5-9562-fad7fdc7668b.png)
