### PR TITLE
Add standalone Minitest support to test runner

### DIFF
--- a/Support/RubyMate/run_script.rb
+++ b/Support/RubyMate/run_script.rb
@@ -41,7 +41,7 @@ if ARGV.first == "--name="
 end
 
 is_test_script = !(ENV["TM_FILEPATH"].match(/(?:\b|_)(?:tc|ts|test)(?:\b|_)/).nil? and
-  File.read(ENV["TM_FILEPATH"]).match(/\brequire\b.+(?:test\/unit|test_helper)/).nil?)
+  File.read(ENV["TM_FILEPATH"]).match(/\brequire\b.+(?:test\/unit|test_helper|minitest)/).nil?)
 
 cmd = [ENV['TM_RUBY'] || 'ruby', '-rcatch_exception']
 
@@ -132,8 +132,8 @@ TextMate::Executor.run( cmd, :version_args => ["--version"],
       elsif line =~ /([\w\_]+).*\[([\w\_\/\.]+)\:(\d+)\]/   # whatever_message....[function_name/.whatever:line_no]
         method, file, line = $1, $2, $3
         "<span><a href=\"txmt://open?#{path_to_url_chunk(file)}line=#{line}\">#{method}</a></span>:#{line}<br/>"
-      elsif line =~ /^\d+ tests, \d+ assertions, (\d+) failures, (\d+) errors\b.*/
-        "<div class=\"test #{$1 + $2 == "00" ? "ok" : "fail"}\">#{$&}</div>\n"
+      elsif line =~ /^\d+ (tests|runs), \d+ assertions, (\d+) failures, (\d+) errors\b.*/
+        "<div class=\"test #{$2 + $3 == "00" ? "ok" : "fail"}\">#{$&}</div>\n"
       end
     end
   end


### PR DESCRIPTION
Before this change, the test runner didn't detect minitest/autorun, the standard test framework nowadays. This adds working colorization and clickable file links.

Before:

<img width="882" alt="screen shot 2015-11-06 at 11 26 50" src="https://cloud.githubusercontent.com/assets/7542/10995006/222201a2-847a-11e5-9f1c-9260a4808b0f.png">

After:

<img width="882" alt="screen shot 2015-11-06 at 11 27 28" src="https://cloud.githubusercontent.com/assets/7542/10995019/31ef918a-847a-11e5-8e7f-3f6aefc816dc.png">

The older test/unit stuff still works.
