### PR TITLE
run_script: make test matching use pattern.

### DIFF
--- a/Support/RubyMate/run_script.rb
+++ b/Support/RubyMate/run_script.rb
@@ -24,11 +24,11 @@ if ARGV.first == "--name="
     should    = $3 || $4 if lines.find { |line| line =~ /^\s*(should)\s+('(.*)'|"(.*)")+\s*(\{|do)/ }
     context   = $3 || $4 if lines.find { |line| line =~ /^\s*(context)\s+('(.*)'|"(.*)")+\s*(\{|do)/ }
   end
-  
+
   if name and !name.empty?
     args << "--name=#{name}"
   elsif test_name and !test_name.empty?
-    args << "--name=test_#{test_name.gsub(/\s+/,'_')}"
+    args << "--name=/#{test_name.gsub(/\s+/,'_')}/"
   elsif spec and !spec.empty? and context and !context.empty?
     args << %Q{--name="/test_spec \\{.*#{context}\\} \\d{3} \\[#{spec}\\]/"}
   elsif should and !should.empty? and context and !context.empty?


### PR DESCRIPTION
In my experience the previous version was not always enough to match across various test systems that may have additional ways of generating the names for tests.

Let me know if this is the wrong approach and I'll try and work on another approach you suggest to fix my problems.