### PR TITLE
Support old-style hashes without spaces before/after `=>`

### DIFF
--- a/Commands/Convert Ruby hash to 1_9 syntax.tmCommand
+++ b/Commands/Convert Ruby hash to 1_9 syntax.tmCommand
@@ -10,7 +10,7 @@
 def toggle_ruby_hash_syntax(str)
   case str
   when /\=&gt;/
-    str.gsub!(/:(\w+)\s+=&gt;\s+/, '\1: ')
+    str.gsub!(/:(\w+)\s*=&gt;\s*/, '\1: ')
   when /(\w+):/
     str.gsub!(/(\w+):(\s*(?:"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|\w+\([^)]*\)|[^,]+))/, ":\\1 =&gt;\\2")
   else


### PR DESCRIPTION
The spaces are optional (for example, `pp` generates hashes without spaces around `=>`).