### PR TITLE
Associate with .vagrantplugins

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -56,6 +56,7 @@
 		<string>Guardfile</string>
 		<string>Hobofile</string>
 		<string>Vagrantfile</string>
+		<string>.vagrantplugins</string>
 		<string>Appraisals</string>
 		<string>Rantfile</string>
 		<string>Berksfile</string>


### PR DESCRIPTION
.vagrantplugins is basically a pre-execution ruby script. A lot of people use it to automatically install vagrant plugins.