### PR TITLE
Add Command to Reformat Current Document

### DIFF
--- a/Commands/Help.tmCommand
+++ b/Commands/Help.tmCommand
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/bin/bash
+
+. "$TM_SUPPORT_PATH/lib/webpreview.sh"
+
+html_header "Ruby Bundle Help" "Ruby"
+"$TM_SUPPORT_PATH/lib/markdown_to_help.rb" \
+  "$TM_BUNDLE_SUPPORT/help/help.markdown"
+html_footer</string>
+	<key>input</key>
+	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>name</key>
+	<string>Help</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>html</string>
+	<key>outputLocation</key>
+	<string>newWindow</string>
+	<key>scope</key>
+	<string>source.ruby</string>
+	<key>uuid</key>
+	<string>535AF150-5613-44DB-AB41-EBB934A5865F</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveActiveFile</string>
+	<key>command</key>
+	<string>#!/bin/bash
+
+aha_found=`which aha`
+if [ $aha_found ]; then
+  color='n';
+  format='--html'
+else
+  format='--text'
+fi
+
+output=`rubocop -a$color "${TM_FILEPATH}"`
+if [ $aha_found ]; then output=`echo "$output" | aha`; fi
+
+"$DIALOG" tooltip "$format" "$output"</string>
+	<key>input</key>
+	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>^H</string>
+	<key>name</key>
+	<string>Reformat Document</string>
+	<key>outputCaret</key>
+	<string>interpolateByChar</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>discard</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>rubocop</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/bin/rubocop</string>
+			</array>
+		</dict>
+	</array>
+	<key>scope</key>
+	<string>source.ruby</string>
+	<key>uuid</key>
+	<string>64BB4EE2-2803-410C-B140-EA545A13F250</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -7,7 +7,15 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
+[[ -f "$HOME/.rvm/scripts/rvm" ]] &amp;&amp; . "$HOME/.rvm/scripts/rvm"
+
 (
+if [[ ! `which rubocop` ]]; then
+  "$DIALOG" tooltip --text "This command requires RuboCop.
+Please install RuboCop via “gem install rubocop”."
+  exit
+fi
+
 aha_found=`which aha`
 if [ $aha_found ]; then
   color='n';
@@ -43,6 +51,7 @@ if [ $aha_found ]; then output=`echo "$output" | aha`; fi
 			<key>locations</key>
 			<array>
 				<string>$HOME/.rbenv/shims/rubocop</string>
+				<string>$HOME/.rvm/scripts/rvm</string>
 			</array>
 		</dict>
 	</array>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -7,6 +7,7 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
+(
 aha_found=`which aha`
 if [ $aha_found ]; then
   color='n';
@@ -18,7 +19,8 @@ fi
 output=`rubocop -a$color "${TM_FILEPATH}"`
 if [ $aha_found ]; then output=`echo "$output" | aha`; fi
 
-"$DIALOG" tooltip "$format" "$output"</string>
+"$DIALOG" tooltip "$format" "$output"
+) &amp;&gt;/dev/null &amp;</string>
 	<key>input</key>
 	<string>none</string>
 	<key>inputFormat</key>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -3,40 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
-	<string>saveActiveFile</string>
+	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/bin/bash
+	<string>#!usr/bin/env ruby18
 
-cd "${TM_PROJECT_DIRECTORY:-$(dirname "$TM_FILEPATH")}"
-[[ -f "$HOME/.rvm/scripts/rvm" ]] &amp;&amp; . "$HOME/.rvm/scripts/rvm"
+# -- Imports -------------------------------------------------------------------
 
-(
-if [[ -f "Gemfile" ]]; then
-  bundle list rubocop &amp;&amp; bundler_rubocop='bundle exec rubocop'
-fi
+require ENV['TM_BUNDLE_SUPPORT'] + '/lib/rubocop'
 
-if [[ ! `which rubocop` &amp;&amp; -z "$bundler_rubocop" ]]; then
-  "$DIALOG" tooltip --text "This command requires RuboCop.
-Please install RuboCop via “gem install rubocop”."
-  exit
-fi
+# -- Main ----------------------------------------------------------------------
 
-aha_found=`which aha`
-if [[ $aha_found ]]; then
-  color='n';
-  format='--html'
-else
-  format='--text'
-fi
-
-rubocop="${bundler_rubocop:-"${TM_RUBOCOP:-rubocop}"}"
-output=`$rubocop -a$color "$TM_FILEPATH"`
-if [[ $aha_found ]]; then output=`echo "$output" | aha`; fi
-
-"$DIALOG" tooltip "$format" "$output"
-) &amp;&gt;/dev/null &amp;</string>
+RuboCop.reformat
+</string>
 	<key>input</key>
-	<string>none</string>
+	<string>document</string>
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
@@ -44,7 +24,7 @@ if [[ $aha_found ]]; then output=`echo "$output" | aha`; fi
 	<key>name</key>
 	<string>Reformat Document</string>
 	<key>outputCaret</key>
-	<string>interpolateByChar</string>
+	<string>heuristic</string>
 	<key>outputFormat</key>
 	<string>text</string>
 	<key>outputLocation</key>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -16,7 +16,7 @@ else
   format='--text'
 fi
 
-output=`rubocop -a$color "${TM_FILEPATH}"`
+output=`"${TM_RUBOCOP:-rubocop}" -a$color "$TM_FILEPATH"`
 if [ $aha_found ]; then output=`echo "$output" | aha`; fi
 
 "$DIALOG" tooltip "$format" "$output"

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -7,12 +7,12 @@
 	<key>command</key>
 	<string>#!/bin/bash
 
+cd "${TM_PROJECT_DIRECTORY:-$(dirname "$TM_FILEPATH")}"
 [[ -f "$HOME/.rvm/scripts/rvm" ]] &amp;&amp; . "$HOME/.rvm/scripts/rvm"
 
 (
-bundler_dir="${TM_PROJECT_DIRECTORY:-$(dirname "$TM_FILEPATH")}"
-if [[ -f "$bundler_dir/Gemfile" ]]; then
-  cd "$bundler_dir" &amp;&amp; bundle list rubocop
+if [[ -f "Gemfile" ]]; then
+  bundle list rubocop
   if [[ $? == 0 ]]; then bundler_rubocop='bundle exec rubocop'; fi
 fi
 

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -10,7 +10,13 @@
 [[ -f "$HOME/.rvm/scripts/rvm" ]] &amp;&amp; . "$HOME/.rvm/scripts/rvm"
 
 (
-if [[ ! `which rubocop` ]]; then
+bundler_dir="${TM_PROJECT_DIRECTORY:-$(dirname "$TM_FILEPATH")}"
+if [[ -f "$bundler_dir/Gemfile" ]]; then
+  cd "$bundler_dir" &amp;&amp; bundle list rubocop
+  if [[ $? == 0 ]]; then bundler_rubocop='bundle exec rubocop'; fi
+fi
+
+if [[ ! `which rubocop` &amp;&amp; -z "$bundler_rubocop" ]]; then
   "$DIALOG" tooltip --text "This command requires RuboCop.
 Please install RuboCop via “gem install rubocop”."
   exit
@@ -24,7 +30,8 @@ else
   format='--text'
 fi
 
-output=`"${TM_RUBOCOP:-rubocop}" -a$color "$TM_FILEPATH"`
+rubocop="${TM_RUBOCOP:-"${bundler_rubocop:-rubocop}"}"
+output=`$rubocop -a$color "$TM_FILEPATH"`
 if [ $aha_found ]; then output=`echo "$output" | aha`; fi
 
 "$DIALOG" tooltip "$format" "$output"

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -30,7 +30,7 @@ else
   format='--text'
 fi
 
-rubocop="${TM_RUBOCOP:-"${bundler_rubocop:-rubocop}"}"
+rubocop="${bundler_rubocop:-"${TM_RUBOCOP:-rubocop}"}"
 output=`$rubocop -a$color "$TM_FILEPATH"`
 if [[ $aha_found ]]; then output=`echo "$output" | aha`; fi
 

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -23,7 +23,7 @@ Please install RuboCop via “gem install rubocop”."
 fi
 
 aha_found=`which aha`
-if [ $aha_found ]; then
+if [[ $aha_found ]]; then
   color='n';
   format='--html'
 else
@@ -32,7 +32,7 @@ fi
 
 rubocop="${TM_RUBOCOP:-"${bundler_rubocop:-rubocop}"}"
 output=`$rubocop -a$color "$TM_FILEPATH"`
-if [ $aha_found ]; then output=`echo "$output" | aha`; fi
+if [[ $aha_found ]]; then output=`echo "$output" | aha`; fi
 
 "$DIALOG" tooltip "$format" "$output"
 ) &amp;&gt;/dev/null &amp;</string>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -57,6 +57,7 @@ if [[ $aha_found ]]; then output=`echo "$output" | aha`; fi
 			<string>rubocop</string>
 			<key>locations</key>
 			<array>
+				<string>/usr/local/bin/rubocop</string>
 				<string>$HOME/.rbenv/shims/rubocop</string>
 				<string>$HOME/.rvm/scripts/rvm</string>
 			</array>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -42,7 +42,7 @@ if [ $aha_found ]; then output=`echo "$output" | aha`; fi
 			<string>rubocop</string>
 			<key>locations</key>
 			<array>
-				<string>/usr/bin/rubocop</string>
+				<string>$HOME/.rbenv/shims/rubocop</string>
 			</array>
 		</dict>
 	</array>

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -12,8 +12,7 @@ cd "${TM_PROJECT_DIRECTORY:-$(dirname "$TM_FILEPATH")}"
 
 (
 if [[ -f "Gemfile" ]]; then
-  bundle list rubocop
-  if [[ $? == 0 ]]; then bundler_rubocop='bundle exec rubocop'; fi
+  bundle list rubocop &amp;&amp; bundler_rubocop='bundle exec rubocop'
 fi
 
 if [[ ! `which rubocop` &amp;&amp; -z "$bundler_rubocop" ]]; then

--- a/Support/help/help.markdown
+++ b/Support/help/help.markdown
@@ -7,15 +7,17 @@ The command “Reformat Document” – accessible via <kbd>^</kbd> + <kbd>⇧</
 
 ## RuboCop Version
 
-Which version of [RuboCop][] “Reformat Document” uses depends on your environment. The command will try the following options in the given order:
+Which version of [RuboCop][] “Reformat Document” uses depends on your environment. The command will try the options below in the given order:
 
-1. The version of `rubocop` installed via [Bundler][].
-2. The value of the path specified in `TM_RUBOCOP`.
-3. The version of `rubocop` installed via [RVM][]. (The command assumes that you installed RVM in your home directory.)
-4. Any other version of `rubocop` accessible via
-  1. `/usr/local/bin/rubocop`,
-  2. `$HOME/.rbenv/shims/rubocop` or
-  3.  the locations in your `PATH`.
+1. The value of the command specified via `TM_RUBOCOP`.
+2. A executable version of RuboCop accessible via `bin/rubocop`
+3. The version of `rubocop` installed via [Bundler][].
+4. Any other version of `rubocop` accessible via,
+   - `/usr/local/bin/rubocop`,
+   - `$HOME/.rbenv/shims/rubocop`
+   - or the locations in your `PATH`.
+
+ “Reformat Document” prefers [RVM][] install location of `rubocop` for all of the applicable options above.
 
 [Bundler]: https://bundler.io
 [RVM]: https://rvm.io

--- a/Support/help/help.markdown
+++ b/Support/help/help.markdown
@@ -1,0 +1,21 @@
+# Reformat Document
+
+The command “Reformat Document” – accessible via <kbd>^</kbd> + <kbd>⇧</kbd>  +  <kbd>H</kbd> – formats the current document using the `--auto-correct` option of [RuboCop][]. It also shows information about the formatting status in a floating tooltip. The command displays the information about the formatting status either as black text only, or as colorful text if [aha][] is accessible via `PATH`.
+
+[aha]: https://github.com/theZiz/aha
+[RuboCop]: https://github.com/bbatsov/rubocop
+
+## RuboCop Version
+
+Which version of [RuboCop][] “Reformat Document” uses depends on your environment. The command will try the following options in the given order:
+
+1. The version of `rubocop` installed via [Bundler][].
+2. The value of the path specified in `TM_RUBOCOP`.
+3. The version of `rubocop` installed via [RVM][]. (The command assumes that you installed RVM in your home directory.)
+4. Any other version of `rubocop` accessible via
+  1. `/usr/local/bin/rubocop`,
+  2. `$HOME/.rbenv/shims/rubocop` or
+  3.  the locations in your `PATH`.
+
+[Bundler]: https://bundler.io
+[RVM]: https://rvm.io

--- a/Support/help/help.markdown
+++ b/Support/help/help.markdown
@@ -5,6 +5,10 @@ The command “Reformat Document” – accessible via <kbd>^</kbd> + <kbd>⇧</
 [aha]: https://github.com/theZiz/aha
 [RuboCop]: https://github.com/bbatsov/rubocop
 
+## Additional Options
+
+You can specify additional RuboCop options by setting the environment variable `TM_RUBOCOP_OPTIONS`. For example, if RuboCop should only autocorrect layout specific issues set the variable to the value `--only Layout`.
+
 ## RuboCop Version
 
 Which version of [RuboCop][] “Reformat Document” uses depends on your environment. The command will try the options below in the given order.

--- a/Support/help/help.markdown
+++ b/Support/help/help.markdown
@@ -7,17 +7,17 @@ The command “Reformat Document” – accessible via <kbd>^</kbd> + <kbd>⇧</
 
 ## RuboCop Version
 
-Which version of [RuboCop][] “Reformat Document” uses depends on your environment. The command will try the options below in the given order:
+Which version of [RuboCop][] “Reformat Document” uses depends on your environment. The command will try the options below in the given order.
 
 1. The value of the command specified via `TM_RUBOCOP`.
-2. A executable version of RuboCop accessible via `bin/rubocop`
+2. An executable version of RuboCop accessible via `bin/rubocop`.
 3. The version of `rubocop` installed via [Bundler][].
 4. Any other version of `rubocop` accessible via,
    - `/usr/local/bin/rubocop`,
    - `$HOME/.rbenv/shims/rubocop`
    - or the locations in your `PATH`.
 
- “Reformat Document” prefers [RVM][] install location of `rubocop` for all of the applicable options above.
+ “Reformat Document” prefers [RVM][] install locations of `rubocop` for all of the applicable options above.
 
 [Bundler]: https://bundler.io
 [RVM]: https://rvm.io

--- a/Support/lib/rubocop.rb
+++ b/Support/lib/rubocop.rb
@@ -1,0 +1,83 @@
+# rubocop: disable AsciiComments
+# rubocop: disable Style/HashSyntax
+
+# -- Imports -------------------------------------------------------------------
+
+require ENV['TM_BUNDLE_SUPPORT'] + '/lib/executable'
+
+require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'
+require ENV['TM_SUPPORT_PATH'] + '/lib/progress'
+require ENV['TM_SUPPORT_PATH'] + '/lib/tm/detach'
+require ENV['TM_SUPPORT_PATH'] + '/lib/tm/save_current_document'
+
+# -- Module --------------------------------------------------------------------
+
+# This module allows you to reformat files via RuboCop.
+module RuboCop
+  class << self
+    # This function reformats the current TextMate document using RuboCop.
+    #
+    # It works both on saved and unsaved files:
+    #
+    # 1. In the case of an unsaved files this method will stall until RuboCop
+    #    fixed the file. While this process takes place the method displays a
+    #    progress bar.
+    #
+    # 2. If the current document is a file saved somewhere on your disk, then
+    #    the method will not wait until RuboCop is finished. Instead it will run
+    #    RuboCop in the background. This has the advantage, that you can still
+    #    work inside TextMate, while RuboCop works on the document.
+    #
+    # After RuboCop finished reformatting the file, the method will inform you
+    # – via a tooltip – about the problems RuboCop found in the *previous*
+    # version of the document.
+    def reformat
+      unsaved_file = true unless ENV['TM_FILEPATH']
+      TextMate.save_if_untitled('rb')
+      format_file(locate_rubocop, unsaved_file)
+    end
+
+    private
+
+    def locate_rubocop
+      Dir.chdir(ENV['TM_PROJECT_DIRECTORY'] ||
+                File.dirname(ENV['TM_FILEPATH'].to_s))
+      begin
+        Executable.find('rubocop').join ' '
+      rescue Executable::NotFound => error
+        return 'rubocop' if File.executable?(`which rubocop`.rstrip)
+        TextMate.exit_show_tool_tip(error.message)
+      end
+    end
+
+    def format_file(rubocop, unsaved_file)
+      aha = `which aha`.rstrip
+      output_format = aha ? :html : :text
+      command = "#{rubocop} -a#{'n' if aha} \"$TM_FILEPATH\"" \
+                "#{' | aha' if aha} 2>&1"
+      if unsaved_file
+        format_unsaved(command, output_format)
+      else
+        format_saved(command, output_format)
+      end
+    end
+
+    def format_unsaved(rubocop_command, output_format)
+      output, success = TextMate.call_with_progress(
+        :title => '🤖 RuboCop', :summary => 'Reformatting File'
+      ) do
+        [`#{rubocop_command}`, $CHILD_STATUS.success?]
+      end
+      TextMate.exit_show_tool_tip(output) unless success
+      TextMate::UI.tool_tip(output, :format => output_format)
+      TextMate.exit_replace_document(File.read(ENV['TM_FILEPATH']))
+    end
+
+    def format_saved(rubocop_command, output_format)
+      TextMate.detach do
+        output = `#{rubocop_command}`
+        TextMate::UI.tool_tip(output, :format => output_format)
+      end
+    end
+  end
+end

--- a/Support/lib/rubocop.rb
+++ b/Support/lib/rubocop.rb
@@ -53,7 +53,8 @@ module RuboCop
     def format_file(rubocop, unsaved_file)
       aha = `which aha`.rstrip.match(/.+/)
       output_format = aha ? :html : :text
-      command = "#{rubocop} -a \"$TM_FILEPATH\" #{'--color | aha' if aha} 2>&1"
+      command = "#{rubocop} -a \"$TM_FILEPATH\" $TM_RUBOCOP_OPTIONS \
+                 #{'--color | aha' if aha} 2>&1"
       if unsaved_file
         format_unsaved(command, output_format)
       else

--- a/Support/lib/rubocop.rb
+++ b/Support/lib/rubocop.rb
@@ -51,10 +51,9 @@ module RuboCop
     end
 
     def format_file(rubocop, unsaved_file)
-      aha = `which aha`.rstrip
+      aha = `which aha`.rstrip.match(/.+/)
       output_format = aha ? :html : :text
-      command = "#{rubocop} -a#{'n' if aha} \"$TM_FILEPATH\"" \
-                "#{' | aha' if aha} 2>&1"
+      command = "#{rubocop} -a \"$TM_FILEPATH\" #{'--color | aha' if aha} 2>&1"
       if unsaved_file
         format_unsaved(command, output_format)
       else

--- a/info.plist
+++ b/info.plist
@@ -28,6 +28,7 @@
 			<string>------------------------------------</string>
 			<string>D5660BB2-C554-4694-9E0F-F20CDB6B9EA0</string>
 			<string>6EA7AE06-3EA9-497D-A6DE-732DE43DA6E9</string>
+			<string>535AF150-5613-44DB-AB41-EBB934A5865F</string>
 			<string>------------------------------------</string>
 			<string>8646378E-91F5-4771-AC7C-43FC49A93576</string>
 			<string>EE5F19BA-6C02-11D9-92BA-0011242E4184</string>

--- a/info.plist
+++ b/info.plist
@@ -31,6 +31,7 @@
 			<string>------------------------------------</string>
 			<string>8646378E-91F5-4771-AC7C-43FC49A93576</string>
 			<string>EE5F19BA-6C02-11D9-92BA-0011242E4184</string>
+			<string>64BB4EE2-2803-410C-B140-EA545A13F250</string>
 			<string>------------------------------------</string>
 			<string>EE5F1FB2-6C02-11D9-92BA-0011242E4184</string>
 			<string>FBFC214F-B019-4967-95D2-028F374A3221</string>


### PR DESCRIPTION
The command “Reformat Document” formats the current document using the `--auto-correct` option of [RuboCop](https://github.com/bbatsov/rubocop). It also shows information about the formatting status in a floating tooltip. The command displays the information about the formatting status either as black text only, or as colorful text if [aha](https://github.com/theZiz/aha) is accessible via `$PATH`.