### PR TITLE
Adding `private def` to folding rules

### DIFF
--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -11,7 +11,7 @@
 		<key>foldingStartMarker</key>
 		<string>(?x)^
 	    (\s*+
-	        (module|class|def(?!.*\bend\s*$)
+	        (module|class|(private\s+)?def(?!.*\bend\s*$)
 	        |unless|if
 	        |case
 	        |begin


### PR DESCRIPTION
This commit adds folding for the following method definition syntax:

    private def some_method
      # code here
    end