### PR TITLE
Add support for 'Fastfile', the configuration file of fastlane

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -66,6 +66,7 @@
 		<string>arb</string>
 		<string>Dangerfile</string>
 		<string>Brewfile</string>
+		<string>Fastfile</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>^#!/.*\bruby|^#\s+-\*-\s*ruby\s*-\*-</string>


### PR DESCRIPTION
Fastlane (https://fastlane.tools/) is getting more and more popular among mobile developers. This commit adds support for the configuration file of this ruby tool.