### PR TITLE
Add filetype jb

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -73,6 +73,7 @@
 		<string>Scanfile</string>
 		<string>Snapfile</string>
 		<string>Gymfile</string>
+		<string>jb</string>
 	</array>
 	<key>firstLineMatch</key>
 	<string>^#!/.*\bruby|^#\s+-\*-\s*ruby\s*-\*-</string>


### PR DESCRIPTION
Support .jb file [amatsuda/jb: A simple and fast JSON API template engine for Ruby on Rails](https://github.com/amatsuda/jb)