### PR TITLE
Fix `Executable.find` with RVM when used from other bundle.

### DIFF
--- a/Support/lib/executable.rb
+++ b/Support/lib/executable.rb
@@ -95,11 +95,18 @@ module Executable
     # and the current directory contains an RVM project file.
     def determine_rvm_prefix
       rvm = "#{ENV['HOME']}/.rvm/bin/rvm"
-      %W(#{ENV['TM_BUNDLE_SUPPORT']}/bin/rvm_wrapper) if File.exist?(rvm)
+      %W(#{bundle_support_path}/bin/rvm_wrapper) if File.exist?(rvm)
     end
 
     def ruby_version_in_gemfile?
       File.exist?('Gemfile.lock') && File.read('Gemfile.lock') =~ /^RUBY_VERSION/
+    end
+
+    # If `Executable.find` is used from another bundle (like RSpec),
+    # $TM_BUNDLE_SUPPORT will point to that bundle’s support directory, so we
+    # need a different way to determine the correct path.
+    def bundle_support_path
+      File.realpath("#{__dir__}/..")
     end
   end
 end

--- a/Support/test/test_executable.rb
+++ b/Support/test/test_executable.rb
@@ -14,9 +14,7 @@ class TestExecutableFind < Minitest::Test
     ENV['HOME'] = "#{__dir__}/fixtures/sample_project"
     ENV.delete_if{ |name, _value| name.start_with?('TM_') }
 
-    # $TM_BUNDLE_SUPPORT is needed by `Executable.determine_rvm_prefix`
-    ENV['TM_BUNDLE_SUPPORT'] = File.realpath("#{__dir__}/..")
-    @rvm_prefix = "#{ENV['TM_BUNDLE_SUPPORT']}/bin/rvm_wrapper"
+    @rvm_prefix = "#{File.realpath("#{__dir__}/..")}/bin/rvm_wrapper"
   end
 
   def teardown
@@ -141,14 +139,6 @@ class TestExecutableFind < Minitest::Test
 
       # Now for the actual test
       assert_raises(Executable::NotFound){ Executable.find('rbenv_installed_shim') }
-    end
-  end
-
-  def test_rvm_when_used_from_another_bundle
-    with_rvm_installed do
-      with_env('TM_BUNDLE_SUPPORT' => '/some/other/bundle', 'TM_RUBY_BUNDLE_SUPPORT' => ENV['TM_BUNDLE_SUPPORT']) do
-        assert_equal %W(#{@rvm_prefix} bin/rspec), Executable.find('rspec')
-      end
     end
   end
 

--- a/Support/test/test_executable.rb
+++ b/Support/test/test_executable.rb
@@ -144,6 +144,14 @@ class TestExecutableFind < Minitest::Test
     end
   end
 
+  def test_rvm_when_used_from_another_bundle
+    with_rvm_installed do
+      with_env('TM_BUNDLE_SUPPORT' => '/some/other/bundle', 'TM_RUBY_BUNDLE_SUPPORT' => ENV['TM_BUNDLE_SUPPORT']) do
+        assert_equal %W(#{@rvm_prefix} bin/rspec), Executable.find('rspec')
+      end
+    end
+  end
+
   def test_find_precedence
     # Make sure we start with a directory with no Gemfile or binstubs, and also with no environment variable.
     Dir.mktmpdir do |dir|


### PR DESCRIPTION
If the Ruby bundle is not the primary bundle but used from another bundle (by declaring a dependency), `$TM_BUNDLE_SUPPORT_PATH` will point to that bundle’s support directory. This lead to a wrong path being generated for the `rvw_wrapper` script in these cases. See https://github.com/rspec/rspec.tmbundle/issues/108 for an example.