### PR TITLE
Add frozen string literal magic comment snippet

### DIFF
--- a/Snippets/# frozen_string_literal: true.tmSnippet
+++ b/Snippets/# frozen_string_literal: true.tmSnippet
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string># frozen_string_literal: ${1:true}
+</string>
+	<key>name</key>
+	<string># frozen_string_literal: true</string>
+	<key>scope</key>
+	<string>source.ruby</string>
+	<key>tabTrigger</key>
+	<string>frozen</string>
+	<key>uuid</key>
+	<string>F8D36847-D339-4563-AB28-E22C71B9CBF7</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -232,6 +232,7 @@
 					<string>------------------------------------</string>
 					<string>A05CBDD6-845D-45EB-94FB-F8787F5456BE</string>
 					<string>B2C3ADE8-E19E-4B87-9C6C-593D490114C7</string>
+					<string>F8D36847-D339-4563-AB28-E22C71B9CBF7</string>
 					<string>97DE939B-D243-4D5C-B953-1C9090912E7C</string>
 					<string>33969819-62C5-4E03-B824-C2337205F364</string>
 					<string>34FEBB9F-73CD-4DD4-A0A3-1CF2A5E3DE78</string>


### PR DESCRIPTION
This pull request add a snippet for the magic comment, `# frozen_string_literal: true`. By typing `frozen`, followed by pressing tab, it will expand to the complete comment.