### PR TITLE
Rename assert_raise to assert_raises

### DIFF
--- a/Snippets/assert_raises(..) { .. }  (asr).plist
+++ b/Snippets/assert_raises(..) { .. }  (asr).plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>assert_raise(${1:Exception}) { $0 }</string>
+	<string>assert_raises(${1:Exception}) { $0 }</string>
 	<key>name</key>
-	<string>assert_raise(..) { .. }</string>
+	<string>assert_raises(..) { .. }</string>
 	<key>scope</key>
 	<string>source.ruby</string>
 	<key>tabTrigger</key>


### PR DESCRIPTION
For Minitest compatibility we rename `assert_raise` to `assert_raises`. Since the TestUnit gem [have an alias for it](https://github.com/test-unit/test-unit/blob/a304da3e169d53689b4419a7611133fd355eaca1/lib/test/unit/assertions.rb#L287), it will both work in both cases.