### PR TITLE
Remove front underscore from variable.other.constant.ruby scope

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -440,7 +440,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b[_A-Z]\w*\b</string>
+			<string>\b[A-Z]\w*\b</string>
 			<key>name</key>
 			<string>variable.other.constant.ruby</string>
 		</dict>


### PR DESCRIPTION
Ruby constant should begins with an uppercase letter.
`_variable_name` is not a constant