### PR TITLE
Multiple exclamation marks

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -1871,7 +1871,7 @@
 			<key>comment</key>
 			<string>Make sure this goes after assignment and comparison</string>
 			<key>match</key>
-			<string>(?&lt;=^|[ \t])!|&amp;&amp;|\|\||\^</string>
+			<string>(?&lt;=^|[ \t!])!|&amp;&amp;|\|\||\^</string>
 			<key>name</key>
 			<string>keyword.operator.logical.ruby</string>
 		</dict>


### PR DESCRIPTION
In expressions like `!!true` only first exclamation mark highlighted. 
Since this syntax is a valid ruby code - 
```ruby
def foo!(b)
  b
end

foo!!!false
```
I added `!` in to positive lookbehind so every `!` operator highlighted correctly