### PR TITLE
Fix typo s/precidence/precedence/

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -805,7 +805,7 @@
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>Needs higher precidence than regular expressions.</string>
+			<string>Needs higher precedence than regular expressions.</string>
 			<key>match</key>
 			<string>(?&lt;!\()/=</string>
 			<key>name</key>


### PR DESCRIPTION
I found this typo from https://github.com/rubyide/vscode-ruby/pull/709 and https://github.com/microsoft/vscode/pull/118923