### PR TITLE
Add `-+!` to allowed regex starters

### DIFF
--- a/Syntaxes/Ruby.plist
+++ b/Syntaxes/Ruby.plist
@@ -930,7 +930,7 @@
 			   (?:
 			     ^                      # beginning of line
 			   | (?&lt;=                   # or look-behind on:
-			       [=&gt;~(?:\[,|&amp;;]
+			       [-+!=&gt;~(?:\[,|&amp;;]
 			     | [\s;]if\s			# keywords
 			     | [\s;]elsif\s
 			     | [\s;]while\s


### PR DESCRIPTION
Fixes https://github.com/textmate/ruby.tmbundle/issues/115